### PR TITLE
Add prepublish in pakcage.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
     "index.js"
   ],
   "scripts": {
+    "clean": "rimraf all.json",
     "build": "gulp build",
     "test": "npm run textlint && npm run textlint:failure",
     "textlint": "textlint ./test/fixtures/",
     "textlint:failure": "! textlint ./test/failure/ && echo 'Test Failure is Success.\nThis failure is indeed!'",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "prepublish": "npm run clean && npm run build"
   },
   "directories": {
     "test": "test/"
@@ -33,6 +35,7 @@
     "gulp": "^3.8.8",
     "gulp-concat": "^2.4.1",
     "prh": "^0.9.0",
+    "rimraf": "^2.5.2",
     "semantic-release": "^4.3.5",
     "textlint": "^5.1.2",
     "textlint-rule-prh": "^2.2.1",


### PR DESCRIPTION
Before publishing, we should run `npm run build` and there is some possibility of forgetting to do it. I have added prepublish script to build `all.json`. what do you think ? 
