### PR TITLE
fix サインイン -> サイトイン to サイトイン -> サインイン

### DIFF
--- a/dict/typo.yml
+++ b/dict/typo.yml
@@ -68,8 +68,8 @@ rules:
   - expected: operator
     patterns: oeprator
 
-  - expected: サイトイン
-    patterns: サインイン
+  - expected: サインイン
+    patterns: サイトイン
 
   - expected: webpack
     patterns: /\bwebpac(?!k)\b/


### PR DESCRIPTION
`122:44  ✓ error  サインイン => サイトイン  preset-japanese/spellcheck-tech-word` というエラーを受けたのですが、コミットメッセージを見るとtypo検出が逆方向に働いているかもしれません。

https://github.com/azu/technical-word-rules/commit/8970a5696ca0ddbef1d16079699e78eb7c5e07a9
