### PR TITLE
Fix references for dictionary to pass a word "react-redux"

### DIFF
--- a/test/failure/react-redux.md
+++ b/test/failure/react-redux.md
@@ -1,0 +1,1 @@
+reduxの世界とReact.jsの世界をつなぐ際はreact-reduxを使います。Reduxで副作用を扱う際はredux-thunkなどを別途検討してください。


### PR DESCRIPTION
This PR reflects changes in https://github.com/azu/prh.yml/commit/5cf8448735da01637aee161ff0543e6dcd1e2a2a